### PR TITLE
feat: Add ZKTeco transactions sync controller with token-based authentication

### DIFF
--- a/zkteco_biometric_integration/zkteco_biometric_integration/controller/zkteco_transactions_sync.py
+++ b/zkteco_biometric_integration/zkteco_biometric_integration/controller/zkteco_transactions_sync.py
@@ -1,0 +1,40 @@
+import frappe
+import requests
+
+from zkteco_biometric_integration.zkteco_biometric_integration.doctype.zkteco_biometric_settings.zkteco_biometric_settings import (
+	ZKTecoBiometricSettings,
+)
+
+
+@frappe.whitelist(allow_guest=True)
+def get_transactions(username):
+	token, url = get_configs(username)
+
+	headers = {"Content-Type": "application/json", "Authorization": f"JWT {token}"}
+
+	url_path = "/iclock/api/transactions/"
+
+	endpoint_url = f"{url}{url_path}"
+
+	try:
+		response = requests.get(endpoint_url, headers=headers)
+		if response.status_code == 200:
+			return response.json().get("data")
+		else:
+			frappe.throw(f"Problem generating transactions: {response.json().get("detail")}")
+
+	except Exception as e:
+		frappe.throw("Problem generating transactions", str(e))
+
+
+@frappe.whitelist(allow_guest=True)
+def get_configs(username):
+	settings_doctype = "ZKTeco Biometric Settings"
+	token, url = frappe.db.get_value(settings_doctype, username, ["token", "url"])
+
+	if not token:
+		token = ZKTecoBiometricSettings.generate_token()
+		frappe.db.set_value(settings_doctype, username, "token", token)
+		return token
+
+	return token, url


### PR DESCRIPTION


This PR introduces a new controller for synchronizing transactions from the ZKTeco biometric system. The controller provides two whitelisted endpoints:

- `get_transactions(username)`: Fetches transaction data from the ZKTeco server for the specified user, using JWT token authentication.
- `get_configs(username)`: Retrieves the stored JWT token and URL for the user from the `ZKTeco Biometric Settings` DocType, and generates a new token if one does not exist.

### Motivation

- **Integration**: Enables Frappe/ERPNext to fetch and process attendance or access transactions from ZKTeco biometric devices.
- **Security**: Uses JWT token-based authentication for secure API access.
- **Automation**: Automatically generates and stores a new token if one is missing, reducing manual intervention.

### Technical Details

- **Endpoints**:
  - `get_transactions(username)`:
    - Retrieves the JWT token and URL for the given username.
    - Makes a GET request to the ZKTeco `/iclock/api/transactions/` endpoint.
    - Returns the transaction data if successful, or throws a descriptive error.
  - `get_configs(username)`:
    - Fetches the `token` and `url` from the `ZKTeco Biometric Settings` DocType.
    - If the token is missing, calls `generate_token()` from the settings DocType, stores the new token, and returns it.
- **Error Handling**:
  - Uses `frappe.throw` to provide clear error messages for both HTTP and general exceptions.

---

## Test via Postman
![Screenshot from 2025-07-10 12-00-41](https://github.com/user-attachments/assets/a00d9958-ffa0-4d0e-a6ea-007e27780795)

## TODO

sync and map the above results from the transaction reponse to the employee checkin doctype