### PR TITLE
feat: Automatically refresh expired JWT tokens for ZKTeco integration

### DIFF
--- a/zkteco_biometric_integration/zkteco_biometric_integration/controller/zkteco_transactions_sync.py
+++ b/zkteco_biometric_integration/zkteco_biometric_integration/controller/zkteco_transactions_sync.py
@@ -1,4 +1,7 @@
+import time
+
 import frappe
+import jwt
 import requests
 
 from zkteco_biometric_integration.zkteco_biometric_integration.doctype.zkteco_biometric_settings.zkteco_biometric_settings import (
@@ -27,14 +30,16 @@ def get_transactions(username):
 		frappe.throw("Problem generating transactions", str(e))
 
 
-@frappe.whitelist(allow_guest=True)
 def get_configs(username):
 	settings_doctype = "ZKTeco Biometric Settings"
 	token, url = frappe.db.get_value(settings_doctype, username, ["token", "url"])
 
-	if not token:
-		token = ZKTecoBiometricSettings.generate_token()
+	token_payload = jwt.decode(token, options={"verify_signature": False})
+
+	if not token or token_payload.get("exp") < time.time():
+		doctype = frappe.get_doc(settings_doctype, username)
+		token = doctype.generate_token(settings_doctype)
 		frappe.db.set_value(settings_doctype, username, "token", token)
-		return token
+		return token, url
 
 	return token, url

--- a/zkteco_biometric_integration/zkteco_biometric_integration/doctype/zkteco_biometric_settings/zkteco_biometric_settings.py
+++ b/zkteco_biometric_integration/zkteco_biometric_integration/doctype/zkteco_biometric_settings/zkteco_biometric_settings.py
@@ -11,13 +11,19 @@ class ZKTecoBiometricSettings(Document):
 		self.token = self.generate_token()
 		frappe.msgprint("Token generated succesfully")
 
-	def generate_token(self):
+	def generate_token(self, doctype=None):
 		headers = {"Content-Type": "application/json"}
 
-		payload = {"username": self.username, "password": self.password}
 		self.url_path = "/jwt-api-token-auth/"
-
 		endpoint_url = f"{self.url}{self.url_path}"
+
+		if doctype:
+			doc = frappe.get_doc(doctype, self.username)
+			password = doc.get_password("password")
+		else:
+			password = self.password
+
+		payload = {"username": self.username, "password": password}
 
 		try:
 			response = requests.post(endpoint_url, payload, headers)


### PR DESCRIPTION


This pull request introduces improvements to the ZKTeco biometric integration by implementing **automatic JWT token refresh logic** and ensuring that the plaintext password is used during token generation when needed.

---

#### **What was changed**

1. **Token Expiry Check:**

   * We now decode the JWT token using the `jwt` Python module to inspect the `exp` (expiration) claim.
   * If the token is missing or expired, a new token is generated and stored in the `ZKTeco Biometric Settings` doctype.

2. **Password Handling:**

   * When generating a token, if the `doctype` is passed to `generate_token()`, we decrypt the stored password using `get_password()` to ensure the plaintext is used.
   * If no `doctype` is passed, the password is used as-is (`self.password`).

3. **Refactoring:**

   * The `get_configs` function was updated to support automatic token regeneration logic when expired.
   * Minor improvements to payload handling and token assignment for clarity and consistency.

---

#### **Why this is needed**

Previously, tokens were reused indefinitely without checking for expiration, which led to authentication failures once the token expired. The response from the JWT endpoint only included the token and not its expiration date, so we now explicitly decode the token to inspect expiry.

---
### Response for the initial token creation
<img width="1248" height="447" alt="image" src="https://github.com/user-attachments/assets/5f7b277c-803a-4744-be91-8d6747df3ba9" />

This improves the resilience of our integration by:

* Reducing manual intervention to regenerate tokens.
* Ensuring seamless communication with the ZKTeco device/API by always using a valid token.

---

#### **How it works**

* On each request to get transactions, `get_configs()` decodes the current JWT.
* If expired or missing, it calls `generate_token()` to get a new one.
* The new token is stored in the settings doctype for future use.

---

