### PR TITLE
Feat/employee checkin

### DIFF
--- a/zkteco_biometric_integration/zkteco_biometric_integration/controller/zkteco_transactions_sync.py
+++ b/zkteco_biometric_integration/zkteco_biometric_integration/controller/zkteco_transactions_sync.py
@@ -54,13 +54,24 @@ def handle_employee_checkin(username):
 		log_type = "IN" if transaction["punch_state_display"] == "Check-In" else "OUT"
 		punch_time = transaction.get("punch_time")
 
-		employee_checkin = frappe.get_doc(
+		exists = frappe.db.exists(
+			"Employee Checkin",
 			{
 				"doctype": "Employee Checkin",
 				"employee": employee,
 				"log_type": log_type,
 				"time": punch_time,
-			}
+			},
 		)
 
-		employee_checkin.save()
+		if not exists:
+			employee_checkin = frappe.get_doc(
+				{
+					"doctype": "Employee Checkin",
+					"employee": employee,
+					"log_type": log_type,
+					"time": punch_time,
+				}
+			)
+
+		employee_checkin.insert()

--- a/zkteco_biometric_integration/zkteco_biometric_integration/controller/zkteco_transactions_sync.py
+++ b/zkteco_biometric_integration/zkteco_biometric_integration/controller/zkteco_transactions_sync.py
@@ -43,3 +43,24 @@ def get_configs(username):
 		return token, url
 
 	return token, url
+
+
+@frappe.whitelist(allow_guest=True)
+def handle_employee_checkin(username):
+	transactions = get_transactions(username)
+
+	for transaction in transactions:
+		employee = transaction.get("emp_code")
+		log_type = "IN" if transaction["punch_state_display"] == "Check-In" else "OUT"
+		punch_time = transaction.get("punch_time")
+
+		employee_checkin = frappe.get_doc(
+			{
+				"doctype": "Employee Checkin",
+				"employee": employee,
+				"log_type": log_type,
+				"time": punch_time,
+			}
+		)
+
+		employee_checkin.save()

--- a/zkteco_biometric_integration/zkteco_biometric_integration/controller/zkteco_transactions_sync.py
+++ b/zkteco_biometric_integration/zkteco_biometric_integration/controller/zkteco_transactions_sync.py
@@ -74,4 +74,4 @@ def handle_employee_checkin(username):
 				}
 			)
 
-		employee_checkin.insert()
+		employee_checkin.insert(ignore_permissions=True)


### PR DESCRIPTION


This PR adds a new whitelisted server-side function called `handle_employee_checkin`, which automates the process of syncing punch logs from ZKTeco biometric devices into the Frappe HR module's `Employee Checkin` doctype.

---

#### **What This Does**

* Fetches punch transactions using an existing helper method `get_transactions(username)`.
* Parses each transaction and:

  * Extracts the employee code, punch time, and punch type (`Check-In` or `Check-Out`).
  * Maps punch type to Frappe's expected `log_type` values: `"IN"` or `"OUT"`.
  * Checks if a check-in with the same `employee`, `log_type`, and `time` already exists to **avoid duplicates**.
  * If no record exists, creates a new `Employee Checkin` document and inserts it into the system.

---

#### **Access and Permissions**

* The function is marked with `@frappe.whitelist(allow_guest=True)` to support **external device integrations without login sessions**.
* Uses `ignore_permissions=True` in `.insert()` to bypass permission checks (since biometric systems typically use a guest or integration user).

---

<img width="1177" height="525" alt="Screenshot from 2025-07-12 14-11-06" src="https://github.com/user-attachments/assets/7a38c7b9-c3da-4f26-8a33-8d8e7938467b" />

