### PR TITLE
Add Frequency Settings and Refactor Check-In Handling

### DIFF
--- a/zkteco_biometric_integration/zkteco_biometric_integration/controller/zkteco_transactions_sync.py
+++ b/zkteco_biometric_integration/zkteco_biometric_integration/controller/zkteco_transactions_sync.py
@@ -45,36 +45,40 @@ def get_configs(username):
 	return token, url
 
 
-@frappe.whitelist(allow_guest=True)
-def handle_employee_checkin(username):
-	transactions = get_transactions(username)
-	frappe.set_user(f"zkteco_biometric_{username}")
+@frappe.whitelist()
+def handle_employee_checkin():
+	biometric_settings = frappe.get_all(
+		"ZKTeco Biometric Settings", filters={"enable": 1}, fields=["username"]
+	)
 
-	for transaction in transactions:
-		employee = transaction.get("emp_code")
-		log_type = "IN" if transaction["punch_state_display"] == "Check-In" else "OUT"
-		punch_time = transaction.get("punch_time")
+	for setting in biometric_settings:
+		username = setting.username
 
-		exists = frappe.db.exists(
-			"Employee Checkin",
-			{
-				"doctype": "Employee Checkin",
-				"employee": employee,
-				"log_type": log_type,
-				"time": punch_time,
-			},
-		)
+		transactions = get_transactions(username)
+		frappe.set_user(f"zkteco_biometric_{username}")
 
-		if not exists:
-			employee_checkin = frappe.get_doc(
+		for transaction in transactions:
+			employee = transaction.get("emp_code")
+			log_type = "IN" if transaction["punch_state_display"] == "Check-In" else "OUT"
+			punch_time = transaction.get("punch_time")
+
+			exists = frappe.db.exists(
+				"Employee Checkin",
 				{
-					"doctype": "Employee Checkin",
 					"employee": employee,
 					"log_type": log_type,
 					"time": punch_time,
-				}
+				},
 			)
 
-		employee_checkin.insert(ignore_permissions=True)
+			if not exists:
+				frappe.get_doc(
+					{
+						"doctype": "Employee Checkin",
+						"employee": employee,
+						"log_type": log_type,
+						"time": punch_time,
+					}
+				).insert(ignore_permissions=True)
 
 	frappe.db.commit()

--- a/zkteco_biometric_integration/zkteco_biometric_integration/doctype/zkteco_biometric_settings/zkteco_biometric_settings.json
+++ b/zkteco_biometric_integration/zkteco_biometric_integration/doctype/zkteco_biometric_settings/zkteco_biometric_settings.json
@@ -11,7 +11,10 @@
   "column_break_tvyy",
   "url",
   "section_break_vxwc",
-  "token"
+  "token",
+  "frequency_settings_section",
+  "fetch_frequency",
+  "cron_expression"
  ],
  "fields": [
   {
@@ -43,12 +46,29 @@
    "fieldtype": "Text",
    "label": "Token",
    "read_only": 1
+  },
+  {
+   "fieldname": "frequency_settings_section",
+   "fieldtype": "Section Break",
+   "label": "Frequency Settings"
+  },
+  {
+   "fieldname": "fetch_frequency",
+   "fieldtype": "Select",
+   "label": "Fetch Frequency",
+   "options": "All\nHourly\nHourly Long\nHourly Maintenance\nDaily\nDaily Long\nDaily Maintenance\nWeekly\nWeekly Long\nMonthly\nMonthly Long\nCron\nYearl"
+  },
+  {
+   "depends_on": "eval:doc.fetch_frequency===\"Cron\";",
+   "fieldname": "cron_expression",
+   "fieldtype": "Data",
+   "label": "Cron Expression"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-09 13:40:18.328323",
+ "modified": "2025-07-17 14:13:19.536747",
  "modified_by": "Administrator",
  "module": "Zkteco Biometric Integration",
  "name": "ZKTeco Biometric Settings",

--- a/zkteco_biometric_integration/zkteco_biometric_integration/doctype/zkteco_biometric_settings/zkteco_biometric_settings.json
+++ b/zkteco_biometric_integration/zkteco_biometric_integration/doctype/zkteco_biometric_settings/zkteco_biometric_settings.json
@@ -14,7 +14,9 @@
   "token",
   "frequency_settings_section",
   "fetch_frequency",
-  "cron_expression"
+  "cron_expression",
+  "column_break_jdsq",
+  "enable"
  ],
  "fields": [
   {
@@ -63,12 +65,22 @@
    "fieldname": "cron_expression",
    "fieldtype": "Data",
    "label": "Cron Expression"
+  },
+  {
+   "fieldname": "column_break_jdsq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable",
+   "fieldtype": "Check",
+   "label": "Enable"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-17 14:13:19.536747",
+ "modified": "2025-07-17 16:10:37.712968",
  "modified_by": "Administrator",
  "module": "Zkteco Biometric Integration",
  "name": "ZKTeco Biometric Settings",

--- a/zkteco_biometric_integration/zkteco_biometric_integration/doctype/zkteco_biometric_settings/zkteco_biometric_settings.py
+++ b/zkteco_biometric_integration/zkteco_biometric_integration/doctype/zkteco_biometric_settings/zkteco_biometric_settings.py
@@ -7,9 +7,12 @@ from frappe.model.document import Document
 
 
 class ZKTecoBiometricSettings(Document):
-	def before_save(self):
+	def before_insert(self):
 		self.token = self.generate_token()
 		frappe.msgprint("Token generated succesfully")
+
+	def before_save(self):
+		self.manage_checkin_scheduler()
 
 	def generate_token(self, doctype=None):
 		headers = {"Content-Type": "application/json"}


### PR DESCRIPTION


This PR introduces improvements to the ZKTeco Biometric Settings Doctype and the check-in processing logic:

---

#### **New Features – Frequency Settings Section**

A new section has been added to allow scheduling control for biometric data fetching:

* **`fetch_frequency`** (Select field):
  Allows users to define how often the system should fetch check-in records. Available options include:

  * All
  * Hourly / Hourly Long / Hourly Maintenance
  * Daily / Daily Long / Daily Maintenance
  * Weekly / Weekly Long
  * Monthly / Monthly Long
  * Cron
  * Yearly

* **`cron_expression`** (Data field):
  Accepts a custom cron expression. This field is conditionally shown only when `fetch_frequency` is set to **Cron**.

* **`enable`** (Check field):
  Toggles whether the scheduled job for employee check-ins should be active.
<img width="877" height="184" alt="image" src="https://github.com/user-attachments/assets/43a15c69-57fc-4f89-83e0-8d01da0216c7" />

---

#### **Refactor – Check-In Handling Logic**

* The `handle_employee_checkin` function has been refactored:

  * Removed the dependency on the `username` parameter.
  * The function now automatically processes all **enabled** biometric settings records.
  * This makes scheduled jobs easier to manage by eliminating the need to pass usernames manually.

---

