### PR TITLE
Check-in Scheduler Automation

### DIFF
--- a/zkteco_biometric_integration/zkteco_biometric_integration/doctype/zkteco_biometric_settings/zkteco_biometric_settings.py
+++ b/zkteco_biometric_integration/zkteco_biometric_integration/doctype/zkteco_biometric_settings/zkteco_biometric_settings.py
@@ -38,3 +38,37 @@ class ZKTecoBiometricSettings(Document):
 
 		except Exception as e:
 			frappe.throw("Problem generating Token", str(e))
+
+
+def manage_checkin_scheduler(self):
+	method = "zkteco_biometric_integration.zkteco_biometric_integration.controller.zkteco_transactions_sync.handle_employee_checkin"
+
+	exists = frappe.db.exists("Scheduled Job Type", {"method": method})
+
+	if self.enable:
+		if not exists:
+			scheduled_job = frappe.get_doc(
+				{
+					"doctype": "Scheduled Job Type",
+					"method": method,
+					"frequency": self.fetch_frequency,
+					"stopped": 0,
+					"cron_format": self.cron_expression if self.fetch_frequency == "Cron" else None,
+				}
+			)
+			scheduled_job.insert()
+
+		frappe.db.set_value(
+			"Scheduled Job Type",
+			{"method": method},
+			{
+				"stopped": 0,
+				"frequency": self.fetch_frequency,
+				"cron_format": self.cron_expression if self.fetch_frequency == "Cron" else None,
+			},
+		)
+
+	else:
+		if exists:
+			frappe.db.set_value("Scheduled Job Type", {"method": method}, "stopped", 1)
+			frappe.delete_doc("Scheduled Job Type", exists)

--- a/zkteco_biometric_integration/zkteco_biometric_integration/doctype/zkteco_biometric_settings/zkteco_biometric_settings.py
+++ b/zkteco_biometric_integration/zkteco_biometric_integration/doctype/zkteco_biometric_settings/zkteco_biometric_settings.py
@@ -39,36 +39,35 @@ class ZKTecoBiometricSettings(Document):
 		except Exception as e:
 			frappe.throw("Problem generating Token", str(e))
 
+	def manage_checkin_scheduler(self):
+		method = "zkteco_biometric_integration.zkteco_biometric_integration.controller.zkteco_transactions_sync.handle_employee_checkin"
 
-def manage_checkin_scheduler(self):
-	method = "zkteco_biometric_integration.zkteco_biometric_integration.controller.zkteco_transactions_sync.handle_employee_checkin"
+		exists = frappe.db.exists("Scheduled Job Type", {"method": method})
 
-	exists = frappe.db.exists("Scheduled Job Type", {"method": method})
+		if self.enable:
+			if not exists:
+				scheduled_job = frappe.get_doc(
+					{
+						"doctype": "Scheduled Job Type",
+						"method": method,
+						"frequency": self.fetch_frequency,
+						"stopped": 0,
+						"cron_format": self.cron_expression if self.fetch_frequency == "Cron" else None,
+					}
+				)
+				scheduled_job.insert()
 
-	if self.enable:
-		if not exists:
-			scheduled_job = frappe.get_doc(
+			frappe.db.set_value(
+				"Scheduled Job Type",
+				{"method": method},
 				{
-					"doctype": "Scheduled Job Type",
-					"method": method,
-					"frequency": self.fetch_frequency,
 					"stopped": 0,
+					"frequency": self.fetch_frequency,
 					"cron_format": self.cron_expression if self.fetch_frequency == "Cron" else None,
-				}
+				},
 			)
-			scheduled_job.insert()
 
-		frappe.db.set_value(
-			"Scheduled Job Type",
-			{"method": method},
-			{
-				"stopped": 0,
-				"frequency": self.fetch_frequency,
-				"cron_format": self.cron_expression if self.fetch_frequency == "Cron" else None,
-			},
-		)
-
-	else:
-		if exists:
-			frappe.db.set_value("Scheduled Job Type", {"method": method}, "stopped", 1)
-			frappe.delete_doc("Scheduled Job Type", exists)
+		else:
+			if exists:
+				frappe.db.set_value("Scheduled Job Type", {"method": method}, "stopped", 1)
+				frappe.delete_doc("Scheduled Job Type", exists)


### PR DESCRIPTION

This PR introduces automated scheduling for fetching employee check-in records from the biometric device, managed via the **ZKTeco Biometric Settings** DocType.

---

### What’s Included

* Added `manage_checkin_scheduler()` method inside `ZKTecoBiometricSettings` to **dynamically create, update, or stop scheduled jobs** based on configuration fields.
* The scheduler uses the **Scheduled Job Type** DocType to trigger `handle_employee_checkin()` on a defined frequency (`Hourly`, `Daily`, `Weekly`, `Cron`, etc.).
* Integrated the scheduler lifecycle with the **before\_save** event, so any changes to settings (like enabling/disabling or frequency changes) automatically reflect in the scheduler without manual intervention.
* Included `handle_employee_checkin()` logic to **query all enabled ZKTeco settings**, fetch transaction logs, and create `Employee Checkin` records.

---

### How It Works

* **When Enabled**:

  * On save, the system checks if a Scheduled Job Type exists for the method `handle_employee_checkin()`.
  * If it doesn’t exist, it creates a new scheduler with the selected frequency (or custom cron expression).
  * If it exists, it **updates the frequency** and **restarts** the scheduler (stopped = 0).
* **When Disabled**:

  * It **disables and deletes the scheduler**, stopping further automatic check-in syncing.

---

### How Check-ins Are Processed

* The scheduler triggers `handle_employee_checkin()` based on the configured frequency.
* The method:

  * **Queries all enabled ZKTeco Biometric Settings**.
  * For each setting, it fetches transaction logs via `get_transactions()`.
  * It loops through the transactions and creates `Employee Checkin` entries for new logs (avoiding duplicates using `frappe.db.exists()`).
  * **Commits the database transaction** to ensure data is saved after each run.

---
when enabled the Scheduled Job Type is created:
<img width="941" height="476" alt="image" src="https://github.com/user-attachments/assets/d7475c59-1beb-4e6b-986f-52eaf6b0336f" />
