### PR TITLE
refactor: rename ZKTeco Biometric Settings to NL ZKTeco Biometric Set…

### DIFF
--- a/zkteco_biometric_integration/zkteco_biometric_integration/controller/zkteco_transactions_sync.py
+++ b/zkteco_biometric_integration/zkteco_biometric_integration/controller/zkteco_transactions_sync.py
@@ -4,10 +4,6 @@ import frappe
 import jwt
 import requests
 
-from zkteco_biometric_integration.zkteco_biometric_integration.doctype.zkteco_biometric_settings.zkteco_biometric_settings import (
-	ZKTecoBiometricSettings,
-)
-
 
 @frappe.whitelist(allow_guest=True)
 def get_transactions(username):
@@ -32,7 +28,7 @@ def get_transactions(username):
 
 
 def get_configs(username):
-	settings_doctype = "ZKTeco Biometric Settings"
+	settings_doctype = "NL ZKTeco Biometric Settings"
 	token, url = frappe.db.get_value(settings_doctype, username, ["token", "url"])
 
 	token_payload = jwt.decode(token, options={"verify_signature": False})
@@ -49,7 +45,7 @@ def get_configs(username):
 @frappe.whitelist()
 def handle_employee_checkin():
 	biometric_settings = frappe.get_all(
-		"ZKTeco Biometric Settings", filters={"enable": 1}, fields=["username"]
+		"NL ZKTeco Biometric Settings", filters={"enable": 1}, fields=["username"]
 	)
 
 	for setting in biometric_settings:

--- a/zkteco_biometric_integration/zkteco_biometric_integration/doctype/nl_zkteco_biometric_settings/nl_zkteco_biometric_settings.js
+++ b/zkteco_biometric_integration/zkteco_biometric_integration/doctype/nl_zkteco_biometric_settings/nl_zkteco_biometric_settings.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2025, Navari Limited and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("ZKTeco Biometric Settings", {
+// frappe.ui.form.on("NL ZKTeco Biometric Settings", {
 // 	refresh(frm) {
 
 // 	},

--- a/zkteco_biometric_integration/zkteco_biometric_integration/doctype/nl_zkteco_biometric_settings/nl_zkteco_biometric_settings.json
+++ b/zkteco_biometric_integration/zkteco_biometric_integration/doctype/nl_zkteco_biometric_settings/nl_zkteco_biometric_settings.json
@@ -83,7 +83,7 @@
  "modified": "2025-07-17 16:10:37.712968",
  "modified_by": "Administrator",
  "module": "Zkteco Biometric Integration",
- "name": "ZKTeco Biometric Settings",
+ "name": "NL ZKTeco Biometric Settings",
  "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [

--- a/zkteco_biometric_integration/zkteco_biometric_integration/doctype/nl_zkteco_biometric_settings/nl_zkteco_biometric_settings.py
+++ b/zkteco_biometric_integration/zkteco_biometric_integration/doctype/nl_zkteco_biometric_settings/nl_zkteco_biometric_settings.py
@@ -6,7 +6,7 @@ import requests
 from frappe.model.document import Document
 
 
-class ZKTecoBiometricSettings(Document):
+class NLZKTecoBiometricSettings(Document):
 	def before_insert(self):
 		self.token = self.generate_token()
 		frappe.msgprint("Token generated succesfully")

--- a/zkteco_biometric_integration/zkteco_biometric_integration/doctype/nl_zkteco_biometric_settings/test_nl_zkteco_biometric_settings.py
+++ b/zkteco_biometric_integration/zkteco_biometric_integration/doctype/nl_zkteco_biometric_settings/test_nl_zkteco_biometric_settings.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2025, Navari Limited and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests.utils import FrappeTestCase
 
 
-class TestZKTecoBiometricSettings(FrappeTestCase):
+class TestNLZKTecoBiometricSettings(FrappeTestCase):
 	pass


### PR DESCRIPTION

Renamed the DocType from **ZKTeco Biometric Settings** to **NL ZKTeco Biometric Settings** to introduce a unique namespace prefix (`NL`), ensuring clearer ownership and reducing the risk of DocType name collisions across multiple apps.

### Why this change?
If multiple apps are installed in the same ERPNext instance with similar biometric integrations (e.g., both having `ZKTeco Biometric Settings`), it could lead to conflicts or confusion. Adding the `NL` prefix helps with:
- **App-level distinction** of Doctypes
- **Easier maintenance** in multi-app deployments
- **Better clarity** for internal code organization

This is a **non-breaking renaming** intended for better long-term scalability.

A preventive best practice to ensure cleaner namespace management, especially in cases where both internal and third-party apps coexist.
