### PR TITLE
add guard clauses for better error handling

### DIFF
--- a/zkteco_biometric_integration/zkteco_biometric_integration/controller/zkteco_transactions_sync.py
+++ b/zkteco_biometric_integration/zkteco_biometric_integration/controller/zkteco_transactions_sync.py
@@ -20,7 +20,7 @@ def get_transactions(username):
 		if response.status_code == 200:
 			return response.json().get("data")
 		else:
-			frappe.throw(f"Problem generating transactions: {response.json().get("detail")}")
+			frappe.throw(f"Error generating transactions: {response.json().get("detail")}")
 
 	except Exception as e:
 		frappe.log_error(frappe.get_traceback(), str(e))
@@ -29,6 +29,12 @@ def get_transactions(username):
 
 def get_configs(username):
 	settings = frappe.get_doc("NL ZKTeco Biometric Settings", username)
+	if not settings:
+		frappe.throw(f"Biometric Settings with {username} not found")
+		frappe.log_error(
+			f"Biometric Settings with {username} not found",
+			"ZKTeco Biometric Integration",
+		)
 	token, url = settings.get_settings()
 
 	return token, url

--- a/zkteco_biometric_integration/zkteco_biometric_integration/controller/zkteco_transactions_sync.py
+++ b/zkteco_biometric_integration/zkteco_biometric_integration/controller/zkteco_transactions_sync.py
@@ -39,6 +39,9 @@ def handle_employee_checkin():
 	biometric_settings = frappe.get_all(
 		"NL ZKTeco Biometric Settings", filters={"enable": 1}, fields=["username"]
 	)
+	if not biometric_settings:
+		frappe.throw("No Biometric Settings found")
+		frappe.log_error("No Biometric Settings found", "ZKTeco Biometric Integration")
 
 	for setting in biometric_settings:
 		username = setting.username


### PR DESCRIPTION
This pull request introduces an important validation to the biometric check-in process. Now, the system will explicitly handle cases where no biometric settings are configured, ensuring errors are surfaced and logged for easier troubleshooting.

Error handling improvements:

* Added a check in `handle_employee_checkin` (in `zkteco_transactions_sync.py`) to throw an error and log it if no biometric settings are found, which improves reliability and makes debugging configuration issues easier.
This pull request introduces improved error handling and logging for biometric settings and transaction synchronization in the `zkteco_biometric_integration` module. The changes help ensure that missing configurations and transaction errors are surfaced clearly and logged for easier troubleshooting.

**Error handling improvements:**

* Added explicit error throwing and logging when biometric settings for a given `username` are not found in the `get_configs` function.
* Added error throwing and logging if no enabled biometric settings are found in the `handle_employee_checkin` function.

**User feedback update:**

* Updated the error message in `get_transactions` to use "Error generating transactions" instead of "Problem generating transactions" for clarity.