### PR TITLE
fix: Data integrity in employee chekin

### DIFF
--- a/zkteco_biometric_integration/zkteco_biometric_integration/api/transactions_sync.py
+++ b/zkteco_biometric_integration/zkteco_biometric_integration/api/transactions_sync.py
@@ -20,7 +20,6 @@ def handle_employee_checkin():
         setting_doc = frappe.get_doc("ZKTeco Biometric Settings", setting.name)
 
         transactions = get_transactions(setting_doc)
-        frappe.log_error(message=str(transactions), title="ZKTeco Transactions Fetched")
         if not transactions:
             return
 
@@ -52,11 +51,6 @@ def get_transactions(setting_doc: Document) -> list[dict]:
         else get_datetime()
     )
     end_time = get_datetime()
-
-    frappe.log_error(
-        message=f"Fetching transactions from {start_time} to {end_time}",
-        title="time window",
-    )
 
     params = {
         "start_time": (start_time.strftime("%Y-%m-%d %H:%M:%S")),
@@ -100,6 +94,16 @@ def get_transactions(setting_doc: Document) -> list[dict]:
 
 
 def create_employee_checkin(transaction: dict) -> None:
+
+    if frappe.db.exists(
+        "Employee Checkin",
+        {
+            "employee": transaction.get("emp_code"),
+            "time": transaction.get("timestamp"),
+            "log_type": map_checkin(transaction.get("punch_state_display")),
+        },
+    ):
+        return
 
     try:
         frappe.set_user("ZKTeco Biometric")


### PR DESCRIPTION
This pull request primarily focuses on cleaning up logging and improving data integrity in the ZKTeco Biometric integration. The main changes include removing unnecessary error logs and adding a check to prevent duplicate employee check-in records.

**Logging improvements:**

* Removed logging of fetched transactions and time window information from `handle_employee_checkin` and `get_transactions` to reduce unnecessary error logs. [[1]](diffhunk://#diff-6b3f02832af61e119dd05d1efb0e70f49d540bfa123f5e97cb2f225d0f3189f5L23) [[2]](diffhunk://#diff-6b3f02832af61e119dd05d1efb0e70f49d540bfa123f5e97cb2f225d0f3189f5L56-L60)

**Data integrity:**

* Added a check in `create_employee_checkin` to prevent creating duplicate `Employee Checkin` records based on employee, timestamp, and log type.