### PR TITLE
Fix/scheduled job

### DIFF
--- a/zkteco_biometric_integration/zkteco_biometric_integration/doctype/zkteco_biometric_settings/zkteco_biometric_settings.json
+++ b/zkteco_biometric_integration/zkteco_biometric_integration/doctype/zkteco_biometric_settings/zkteco_biometric_settings.json
@@ -126,7 +126,7 @@
   },
   {
    "default": "0",
-   "description": "utomatically manages user access based on activity: Disables the user profile upon Check-out and re-enables it upon Check-in.",
+   "description": "Automatically manages user access based on activity: Disables the user profile upon Check-out and re-enables it upon Check-in.",
    "fieldname": "enable_mandatory_checkin",
    "fieldtype": "Check",
    "label": "Enable Mandatory Checkin "
@@ -142,7 +142,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-01-30 14:54:35.708007",
+ "modified": "2026-02-06 14:04:32.673659",
  "modified_by": "Administrator",
  "module": "Zkteco Biometric Integration",
  "name": "ZKTeco Biometric Settings",

--- a/zkteco_biometric_integration/zkteco_biometric_integration/doctype/zkteco_biometric_settings/zkteco_biometric_settings.py
+++ b/zkteco_biometric_integration/zkteco_biometric_integration/doctype/zkteco_biometric_settings/zkteco_biometric_settings.py
@@ -48,9 +48,13 @@ class ZKTecoBiometricSettings(Document):
         token: DF.Text | None
         url: DF.Data
         username: DF.Data
+    # end: auto-generated types
 
-    def before_insert(self):
+    _METHOD = "zkteco_biometric_integration.zkteco_biometric_integration.api.transactions_sync.handle_employee_checkin"
+
+    def after_insert(self):
         self.last_fetched_time = get_datetime()
+        self.create_scheduled_job()
 
     def validate(self):
         self.generate_token()
@@ -72,49 +76,49 @@ class ZKTecoBiometricSettings(Document):
             self.issued_at = get_datetime()
             self.expiry = self.issued_at + timedelta(days=1)
 
-    def manage_checkin_scheduler(self):
-        method = "zkteco_biometric_integration.zkteco_biometric_integration.api.transactions_sync.handle_employee_checkin"
+    def create_scheduled_job(self):
 
-        job = frappe.db.exists("Scheduled Job Type", {"method": method})
+        job = frappe.db.exists("Scheduled Job Type", {"method": self._METHOD})
+
+        if not job:
+            frappe.get_doc(
+                {
+                    "doctype": "Scheduled Job Type",
+                    "method": self._METHOD,
+                    "frequency": self.fetch_frequency,
+                    "stopped": 0,
+                    "create_log": 1,
+                    "cron_format": (
+                        self.cron_expression if self.fetch_frequency == "Cron" else ""
+                    ),
+                }
+            ).insert(ignore_permissions=True)
+
+    def manage_checkin_scheduler(self):
+
+        change_rules = [
+            lambda: self.has_value_changed("fetch_frequency"),
+            lambda: self.has_value_changed("cron_expression"),
+        ]
+
+        if any(change() for change in change_rules):
+            self.update_scheduler()
+
+    def update_scheduler(self):
 
         try:
-            if self.is_fetch_enabled:
-                if not job:
-                    scheduled_job = frappe.get_doc(
-                        {
-                            "doctype": "Scheduled Job Type",
-                            "method": method,
-                            "frequency": self.fetch_frequency,
-                            "stopped": 0,
-                            "create_log": 1,
-                            "cron_format": (
-                                self.cron_expression
-                                if self.fetch_frequency == "Cron"
-                                else None
-                            ),
-                        }
-                    )
-                    scheduled_job.insert(ignore_permissions=True)
 
-                frappe.db.set_value(
-                    "Scheduled Job Type",
-                    {"method": method},
-                    {
-                        "stopped": 0,
-                        "frequency": self.fetch_frequency,
-                        "cron_format": (
-                            self.cron_expression
-                            if self.fetch_frequency == "Cron"
-                            else None
-                        ),
-                    },
-                )
-
-            else:
-                if job:
-                    frappe.db.set_value(
-                        "Scheduled Job Type", {"method": method}, {"stopped": 1}
-                    )
+            frappe.db.set_value(
+                "Scheduled Job Type",
+                {"method": self._METHOD},
+                {
+                    "stopped": 0,
+                    "frequency": self.fetch_frequency,
+                    "cron_format": (
+                        self.cron_expression if self.fetch_frequency == "Cron" else ""
+                    ),
+                },
+            )
 
         except Exception as e:
             frappe.log_error(frappe.get_traceback(), str(e))


### PR DESCRIPTION
This pull request introduces improvements to the scheduling logic for employee check-in synchronization in the `ZKTeco Biometric Settings` module. The main changes involve refactoring how scheduled jobs are created and updated, ensuring that job creation happens after document insertion and that updates are triggered only when relevant fields change.

Enhancements to scheduled job management:

* Refactored the scheduled job creation logic: The `create_scheduled_job` method now creates a scheduled job after a new settings document is inserted, replacing the previous approach of managing it before insertion. (`zkteco_biometric_settings.py`, [zkteco_biometric_integration/zkteco_biometric_integration/doctype/zkteco_biometric_settings/zkteco_biometric_settings.pyR51-R57](diffhunk://#diff-01742c5bb96afce98a431447618446f73add04f90b2899c9ddfb3021cd23191eR51-R57))
* Improved scheduler update logic: The `manage_checkin_scheduler` method now updates the scheduled job only if `fetch_frequency` or `cron_expression` fields have changed, preventing unnecessary updates. (`zkteco_biometric_settings.py`, [zkteco_biometric_integration/zkteco_biometric_integration/doctype/zkteco_biometric_settings/zkteco_biometric_settings.pyL75-L118](diffhunk://#diff-01742c5bb96afce98a431447618446f73add04f90b2899c9ddfb3021cd23191eL75-L118))
* Centralized scheduled job method reference: Introduced a `_METHOD` class variable to avoid hardcoding the job method string in multiple places. (`zkteco_biometric_settings.py`, [zkteco_biometric_integration/zkteco_biometric_integration/doctype/zkteco_biometric_settings/zkteco_biometric_settings.pyR51-R57](diffhunk://#diff-01742c5bb96afce98a431447618446f73add04f90b2899c9ddfb3021cd23191eR51-R57))

Minor corrections:

* Fixed a typo in the settings description for the `enable_mandatory_checkin` field. (`zkteco_biometric_settings.json`, [zkteco_biometric_integration/zkteco_biometric_integration/doctype/zkteco_biometric_settings/zkteco_biometric_settings.jsonL129-R129](diffhunk://#diff-4e8a382455ed9bc4e77d9a741331c3f02d147e45a3eed08a0ced56be6e3665ecL129-R129))
* Updated the `modified` timestamp in the settings JSON file. (`zkteco_biometric_settings.json`, [zkteco_biometric_integration/zkteco_biometric_integration/doctype/zkteco_biometric_settings/zkteco_biometric_settings.jsonL145-R145](diffhunk://#diff-4e8a382455ed9bc4e77d9a741331c3f02d147e45a3eed08a0ced56be6e3665ecL145-R145))