### PR TITLE
fix: prevent null cron_format when saving ZKTeco Global

### DIFF
--- a/zkteco_biometric_integration/zkteco_biometric_integration/doctype/zkteco_global/test_zkteco_global.py
+++ b/zkteco_biometric_integration/zkteco_biometric_integration/doctype/zkteco_global/test_zkteco_global.py
@@ -1,9 +1,12 @@
 # Copyright (c) 2026, Navari Limited and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests import IntegrationTestCase
 
+from zkteco_biometric_integration.zkteco_biometric_integration import (
+	SCHEDULED_JOB_METHOD,
+)
 
 # On IntegrationTestCase, the doctype test records and all
 # link-field test record dependencies are recursively loaded
@@ -12,11 +15,34 @@ EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
-
 class IntegrationTestZKTecoGlobal(IntegrationTestCase):
 	"""
 	Integration tests for ZKTecoGlobal.
 	Use this class for testing interactions between multiple components.
 	"""
 
-	pass
+	def test_save_with_non_cron_frequency(self):
+		doc = frappe.get_doc("ZKTeco Global")
+		doc.fetch_frequency = "All"
+		doc.cron_expression = None
+		doc.save()
+
+		job = frappe.get_doc("Scheduled Job Type", {"method": SCHEDULED_JOB_METHOD})
+		self.assertEqual(job.frequency, "All")
+		self.assertEqual(job.cron_format or "", "")
+
+	def test_save_cron_frequency(self):
+		doc = frappe.get_doc("ZKTeco Global")
+		doc.fetch_frequency = "Cron"
+		doc.cron_expression = "*/15 * * * *"
+		doc.save()
+
+		job = frappe.get_doc("Scheduled Job Type", {"method": SCHEDULED_JOB_METHOD})
+		self.assertEqual(job.frequency, "Cron")
+		self.assertEqual(job.cron_format, "*/15 * * * *")
+
+	def test_cron_without_expression_throws(self):
+		doc = frappe.get_doc("ZKTeco Global")
+		doc.fetch_frequency = "Cron"
+		doc.cron_expression = None
+		self.assertRaises(frappe.ValidationError, doc.save)

--- a/zkteco_biometric_integration/zkteco_biometric_integration/doctype/zkteco_global/zkteco_global.py
+++ b/zkteco_biometric_integration/zkteco_biometric_integration/doctype/zkteco_global/zkteco_global.py
@@ -2,55 +2,60 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
+
 from zkteco_biometric_integration.zkteco_biometric_integration import (
-    SCHEDULED_JOB_METHOD,
+	SCHEDULED_JOB_METHOD,
 )
 
 
 class ZKTecoGlobal(Document):
-    # begin: auto-generated types
-    # This code is auto-generated. Do not modify anything in this block.
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
 
-    from typing import TYPE_CHECKING
+	from typing import TYPE_CHECKING
 
-    if TYPE_CHECKING:
-        from frappe.types import DF
+	if TYPE_CHECKING:
+		from frappe.types import DF
 
-        cron_expression: DF.Data | None
-        fetch_frequency: DF.Literal[
-            "All",
-            "Hourly",
-            "Hourly Long",
-            "Hourly Maintenance",
-            "Daily",
-            "Daily Long",
-            "Daily Maintenance",
-            "Weekly",
-            "Weekly Long",
-            "Monthly",
-            "Monthly Long",
-            "Yearly",
-            "Cron",
-        ]
-    # end: auto-generated types
+		cron_expression: DF.Data | None
+		fetch_frequency: DF.Literal[
+			"All",
+			"Hourly",
+			"Hourly Long",
+			"Hourly Maintenance",
+			"Daily",
+			"Daily Long",
+			"Daily Maintenance",
+			"Weekly",
+			"Weekly Long",
+			"Monthly",
+			"Monthly Long",
+			"Yearly",
+			"Cron",
+		]
+	# end: auto-generated types
 
-    def validate(self):
-        self.update_schedule_job()
+	def validate(self):
+		self.update_schedule_job()
 
-    @property
-    def is_cron(self) -> bool:
-        return self.fetch_frequency == "Cron"
+	@property
+	def is_cron(self) -> bool:
+		return self.fetch_frequency == "Cron"
 
-    def update_schedule_job(self) -> None:
+	def update_schedule_job(self) -> None:
+		if self.is_cron and not self.cron_expression:
+			frappe.throw(_("Cron Expression is required when Fetch Frequency is set to Cron"))
 
-        frequency = self.cron_expression if self.is_cron else self.fetch_frequency
+		job = frappe.db.exists("Scheduled Job Type", {"method": SCHEDULED_JOB_METHOD})
+		if not job:
+			return
 
-        if job := frappe.db.exists(
-            "Scheduled Job Type", {"method": SCHEDULED_JOB_METHOD}
-        ):
-            job_doc = frappe.get_doc("Scheduled Job Type", job)
-            job_doc.db_set(
-                {"cron_format": self.cron_expression, "frequency": frequency},
-                update_modified=False,
-            )
+		frappe.get_doc("Scheduled Job Type", job).db_set(
+			{
+				"frequency": "Cron" if self.is_cron else self.fetch_frequency,
+				"cron_format": self.cron_expression if self.is_cron else "",
+			},
+			update_modified=False,
+		)


### PR DESCRIPTION
This pull request adds integration tests and improves validation and update logic for the scheduling of the ZKTeco biometric integration. The main focus is on ensuring the correct handling of cron and non-cron fetch frequencies, including validation of required fields and proper updates to the related scheduled job.

**Testing improvements:**

* Added integration tests in `test_zkteco_global.py` to verify correct behavior when saving a `ZKTeco Global` document with both cron and non-cron frequencies, and to ensure a validation error is raised if the cron expression is missing when required.

**Validation and scheduling logic:**

* Updated `update_schedule_job` in `zkteco_global.py` to validate that a cron expression is provided when the fetch frequency is set to "Cron", raising a user-friendly error if not.
* Improved the logic for updating the `Scheduled Job Type` document to set the correct `frequency` and `cron_format` fields based on whether cron is used, and to avoid updating if the job does not exist.

**Codebase maintenance:**

* Cleaned up imports in both test and implementation files for clarity and to ensure required constants and modules are available. [[1]](diffhunk://#diff-d37fb1e9a085f04531c3022ba2cdc0aa8b809f1d568b24dd860f39115ea44fe4L4-R9) [[2]](diffhunk://#diff-eec9edbaaed9fdb985cab87098f9d9267dc1a089021ab3ac11c30a9329a328afR5-R7)